### PR TITLE
:abcd: Support Prefix/suffix conversion.

### DIFF
--- a/data/config/keymap.conf
+++ b/data/config/keymap.conf
@@ -38,7 +38,7 @@ PrevCandidate		x||ctrl::p
 RemoveTrigger		X
 PrefixSuffixConversion  hex::0x3e
 
-UpperCases		group::A-K,M-P,R-Z||group::Hex::0x3e
+UpperCases		group::A-K,M-P,R-Z||hex::0x3e
 Direct			group::keycode::0x41,0x43,0x45,0x4b,0x4e,0x51-0x59,0x5b,0x5c,0x5f
 InputChars              group::hex::0x20-0x7e
 

--- a/data/config/keymap.conf
+++ b/data/config/keymap.conf
@@ -36,8 +36,9 @@ PrevCompletion		,
 NextCandidate		hex::0x20||ctrl::n
 PrevCandidate		x||ctrl::p
 RemoveTrigger		X
+PrefixSuffixConversion  hex::0x3e
 
-UpperCases		group::A-K,M-P,R-Z
+UpperCases		group::A-K,M-P,R-Z||group::Hex::0x3e
 Direct			group::keycode::0x41,0x43,0x45,0x4b,0x4e,0x51-0x59,0x5b,0x5c,0x5f
 InputChars              group::hex::0x20-0x7e
 

--- a/src/engine/keymap/SKKKeymapEntry.cpp
+++ b/src/engine/keymap/SKKKeymapEntry.cpp
@@ -72,6 +72,7 @@ static const struct {
     { "RemoveTrigger",          RemoveTrigger,          TYPE_ATTRIBUTE },
     { "InputChars",             InputChars,             TYPE_ATTRIBUTE },
     { "CompConversion",         CompConversion,         TYPE_ATTRIBUTE },
+    { "PrefixSuffixConversion", PrefixSuffixConversion, TYPE_ATTRIBUTE },
 
     { "AlwaysHandled",          AlwaysHandled,          TYPE_HANDLE_OPTION },
     { "PseudoHandled",          PseudoHandled,          TYPE_HANDLE_OPTION },

--- a/src/engine/state/SKKEvent.h
+++ b/src/engine/state/SKKEvent.h
@@ -71,7 +71,8 @@ enum {
     PrevCandidate               = (1 << 11),
     RemoveTrigger               = (1 << 12),
     InputChars			= (1 << 13),
-    CompConversion		= (1 << 14)
+    CompConversion		= (1 << 14),
+    PrefixSuffixConversion      = (1 << 15), // >による接頭語、接尾語変換
 };
 
 // 処理オプション
@@ -109,6 +110,7 @@ public:
     bool IsRemoveTrigger() const                { return attribute & RemoveTrigger; }
     bool IsInputChars() const	                { return attribute & InputChars; }
     bool IsCompConversion() const               { return attribute & CompConversion; }
+    bool IsPrefixSuffixConversion() const       { return attribute & PrefixSuffixConversion; }
 
     const static SKKEvent& Null() {
         static SKKEvent obj(SKK_NULL, 0, 0);
@@ -139,6 +141,7 @@ public:
         TEST_attribute(RemoveTrigger);
         TEST_attribute(InputChars);
         TEST_attribute(CompConversion);
+        TEST_attribute(PrefixSuffixConversion);
 
 #undef TEST_attribute
 

--- a/src/engine/state/SKKStateComposing-inl.h
+++ b/src/engine/state/SKKStateComposing-inl.h
@@ -100,9 +100,13 @@ State SKKState::Edit(const Event& event) {
             completer_.Execute(1);
         }
 
-        if(param.IsNextCandidate() || param.IsCompConversion()) {
+        if(param.IsNextCandidate() || param.IsCompConversion() || param.IsPrefixSuffixConversion()) {
             if(context_->entry.IsEmpty()) {
                 return State::Transition(&SKKState::KanaInput);
+            }
+
+            if(param.IsPrefixSuffixConversion()) {
+                editor_->HandleChar(param.code, param.IsDirect());
             }
 
             if(selector_.Execute(configuration_->MaxCountOfInlineCandidates())) {
@@ -156,6 +160,10 @@ State SKKState::KanaEntry(const Event& event) {
     case SKK_CHAR:
         // 変換
         if(param.IsNextCandidate()) break;
+
+        // 接尾語変換(入力がない場合は>を見出し語に含める)
+        if(!context_->entry.IsEmpty() && param.IsPrefixSuffixConversion()) break;
+
 
         // トグル変換 #1
         if(param.IsToggleKana()) {


### PR DESCRIPTION
本家SKKにある接頭語変換、接尾語変換に対応した。
見出し語に `>` を含めることで、接頭語のみの変換や接尾語のみの変換ができるようになる。

## インストール時の注意
keymap.conf の更新が必要。具体的には以下の変更を含めること。

```diff
--- a/data/config/keymap.conf
+++ b/data/config/keymap.conf
@@ -36,8 +36,9 @@ PrevCompletion                ,
 NextCandidate          hex::0x20||ctrl::n
 PrevCandidate          x||ctrl::p
 RemoveTrigger          X
+PrefixSuffixConversion  hex::0x3e
 
-UpperCases             group::A-K,M-P,R-Z
+UpperCases             group::A-K,M-P,R-Z||group::Hex::0x3e
 Direct                 group::keycode::0x41,0x43,0x45,0x4b,0x4e,0x51-0x59,0x5b,0x5c,0x5f
 InputChars              group::hex::0x20-0x7e
```
## できること
### 接頭語
▽モード かつ 1文字以上入力されている場合、 `>` で▼モードに入る。 また、その際、見出し語の末尾に `>` を追加する。

### 接尾語
かなモード or カナモードの場合、`>` で▽モードに入る。

## 参考
http://www.bookshelf.jp/texi/skk/skk_5.html#SEC62