### PR TITLE
Fix path of IcebergControlTowerTool in README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/platform/mac/proj/build/
+

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An input method without morphological analysis.
 ## How to build
 
 ### Build package/dmg
-Install [Iceberg](http://s.sudre.free.fr/Software/Iceberg.html).  And run `/Library/StartupItems/IcebergControlTowerTool` as root.
+Install [Iceberg](http://s.sudre.free.fr/Software/Iceberg.html).  And run `/Library/StartupItems/IcebergControlTower/IcebergControlTowerTool` as root.
 
 ```
 $ cd aquaskk/platform/mac


### PR DESCRIPTION
The installation path is documented at the "Installation Blueprints" section of ["Installing Iceberg"](http://s.sudre.free.fr/Software/documentation/Iceberg/English.lproj/documentation/Iceberg%20Installation.html).