### PR TITLE
IntelliJ対応

### DIFF
--- a/platform/mac/src/server/SKKInputController.mm
+++ b/platform/mac/src/server/SKKInputController.mm
@@ -352,7 +352,8 @@
     if(bundle) {
         // Info.plist に Java キーが含まれていなければ無視
         if([bundle objectForInfoDictionaryKey:@"Java"] == nil &&
-           [bundle objectForInfoDictionaryKey:@"Eclipse"] == nil) {
+           [bundle objectForInfoDictionaryKey:@"Eclipse"] == nil &&
+           [bundle objectForInfoDictionaryKey:@"JVMOptions"] == nil) {
             [self debug:@"Not Java Application"];
             return;
         }


### PR DESCRIPTION
## 現象

 * IntelliJで、l/q等を入力すると、l/q等が入力されてしまう。(モード変換も発生する)

## 原因

 * Javaアプリケーションでは発生する問題で、workaroundForJREで回避を行なっている。
 * 「Javaアプリケーションである」かどうかの判定は、Info.plistに「Java」もしくは「Eclipse」という文字列があるかどうかで行なっていた。
 * しかし、IntelliJのInfo.plistには、そのどちらも含まれていない

## 対応策

 * IntelliJのInfo.plistにも含まれている「JVMOptions」も判定に追加した。

## 参考: IntelliJのInfo.plist
```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
  <dict>
    <key>CFBundleDevelopmentRegion</key>
    <string>English</string>
    <key>CFBundleDocumentTypes</key>
    <array>
      
      <dict>
        <key>CFBundleTypeExtensions</key>
        <array>
          <string>ipr</string>
        </array>
        <key>CFBundleTypeIconFile</key>
        <string>idea.icns</string>
        <key>CFBundleTypeName</key>
        <string>IntelliJ IDEA Project File</string>
        <key>CFBundleTypeRole</key>
        <string>Editor</string>
      </dict>

      <dict>
        <key>CFBundleTypeExtensions</key>
        <array>
          <string>*</string>
        </array>
        <key>CFBundleTypeName</key>
        <string>All documents</string>
        <key>CFBundleTypeOSTypes</key>
        <array>
          <string>****</string>
        </array>
        <key>CFBundleTypeRole</key>
        <string>Editor</string>
        <key>LSTypeIsPackage</key>
        <false/>
      </dict>
    </array>
    <key>CFBundleExecutable</key>
    <string>idea</string>
    <key>CFBundleIconFile</key>
    <string>idea.icns</string>
    <key>CFBundleInfoDictionaryVersion</key>
    <string>6.0</string>
    <key>CFBundleName</key>
    <string>IntelliJ IDEA</string>
    <key>CFBundlePackageType</key>
    <string>APPL</string>
    <key>CFBundleIdentifier</key>
    <string>com.jetbrains.intellij.ce</string>
    <key>CFBundleSignature</key>
    <string>????</string>
    <key>CFBundleGetInfoString</key>
    <string>IntelliJ IDEA 14.0.3, build IC-139.1117.1. Copyright JetBrains s.r.o., (c) 2000-2015</string>
    <key>CFBundleShortVersionString</key>
    <string>14.0.3</string>
    <key>CFBundleVersion</key>
    <string>IC-139.1117.1</string>
    <key>LSApplicationCategoryType</key>
    <string>public.app-category.developer-tools</string>
    <key>CFBundleHelpBookName</key>
    <string>JetBrains.IJ.help</string>
    <key>CFBundleHelpBookFolder</key>
    <string>IJ.help</string>

    <key>NSHighResolutionCapable</key>
    <true/>

    
    <key>LSArchitecturePriority</key>
    <array><string>x86_64</string><string>i386</string></array>

    <key>LSRequiresNativeExecution</key>
    <string>YES</string>
    <key>LSMinimumSystemVersion</key>
    <string>10.6</string>

    
      <key>CFBundleURLTypes</key>
      <array>
        <dict>
          <key>CFBundleTypeRole</key>
          <string>Editor</string>
          <key>CFBundleURLName</key>
          <string>Stacktrace</string>
          <key>CFBundleURLSchemes</key>
          <array>
            <string>idea</string>
          </array>
        </dict>
      </array>


    <key>JVMOptions</key>
    <dict>
      <key>ClassPath</key>
      <string>$APP_PACKAGE/Contents/lib/bootstrap.jar:$APP_PACKAGE/Contents/lib/extensions.jar:$APP_PACKAGE/Contents/lib/util.jar:$APP_PACKAGE/Contents/lib/jdom.jar:$APP_PACKAGE/Contents/lib/log4j.jar:$APP_PACKAGE/Contents/lib/trove4j.jar:$APP_PACKAGE/Contents/lib/jna.jar</string>

      <key>JVMVersion</key>
      <string>1.6*</string>

      <key>MainClass</key>
      <string>com.intellij.idea.Main</string>
      <key>Properties</key>
      <dict>
        
        <key>idea.paths.selector</key>
        <string>IdeaIC14</string>


        <key>idea.java.redist</key>
        <string>NoJavaDistribution</string>

        <key>idea.home.path</key>
        <string>$APP_PACKAGE/Contents</string>
      </dict>

      <key>VMOptions</key>
      <string>-Dfile.encoding=UTF-8 -ea -Dsun.io.useCanonCaches=false -Djava.net.preferIPv4Stack=true -Djsse.enableSNIExtension=false -XX:+UseConcMarkSweepGC -XX:SoftRefLRUPolicyMSPerMB=50 -Xverify:none -Xbootclasspath/a:../lib/boot.jar</string>

      <key>WorkingDirectory</key>
      <string>$APP_PACKAGE/Contents/bin</string>
    </dict>
  </dict>
</plist>
```