### PR TITLE
OpenJDKをブラックリストに加えた

### DIFF
--- a/platform/mac/src/server/SKKInputController.mm
+++ b/platform/mac/src/server/SKKInputController.mm
@@ -362,6 +362,10 @@
         // Javaを直接起動している
         return YES;
     }
+    if([[client_ bundleIdentifier] hasPrefix:@"net.java.openjdk"]) {
+        // OpenJDKを使っている
+        return YES;
+    }
     if(!bundle) { return NO; }
 
     if([[bundle bundleIdentifier] hasPrefix:@"jp.naver.line.mac"]) {


### PR DESCRIPTION
OpenJDKにもJava for OS Xと同様のl等を無視する不具合があったので、blacklistに加えました。