### PR TITLE
Office 2016のExcelでモード切り替え時にl/L/qが入力されないようにした

### DIFF
--- a/platform/mac/src/server/SKKInputController.mm
+++ b/platform/mac/src/server/SKKInputController.mm
@@ -380,6 +380,10 @@
     if([bundle objectForInfoDictionaryKey:@"JVMOptions"]) {
         return YES;
     }
+    if([[bundle bundleIdentifier] hasPrefix:@"com.microsoft.Excel"] &&
+       [[bundle objectForInfoDictionaryKey:@"CFBundleVersion"] hasPrefix:@"15."]) {
+        return YES;
+    }
     return NO;
 }
 


### PR DESCRIPTION
#37 に対処してみました。
Microsoft Excel for Mac 15.16 (151105)ではうまく動いています。