### PR TITLE
JetBrainsのエディタでC-jで日本語入力に切り換えた時に文字が削除されてしまうので回避する

### DIFF
--- a/platform/mac/src/server/SKKInputController.mm
+++ b/platform/mac/src/server/SKKInputController.mm
@@ -89,7 +89,7 @@
 
     bool result = session_->HandleEvent(param);
 
-    if(current != [menu_ currentInputMode] || param.id == SKK_JMODE) {
+    if(current != [menu_ currentInputMode] && param.id != SKK_JMODE) {
         [self workAroundForSpecificApplications];
     }
 


### PR DESCRIPTION
JetBrainsのエディタで、keymapでC-jに機能が割り当てられていない場合に`cancel key event`が誤爆してしまうようなので、C-jの時は発動しないようにしました。

検証環境です。
```
IntelliJ IDEA 2016.2.3
Build #IU-162.1812.17, built on August 30, 2016
Licensed to IntelliJ IDEA Evaluator
Expiration date: October 17, 2016
JRE: 1.8.0_112-release-b287 x86_64
JVM: OpenJDK 64-Bit Server VM by JetBrains s.r.o

RubyMine 2016.2.3
Build #RM-162.1812.23, built on September 5, 2016
JRE: 1.8.0_112-release-b343 x86_64
JVM: OpenJDK 64-Bit Server VM by JetBrains s.r.o

PyCharm 2016.1.4
Build #PY-145.1504, built on May 25, 2016
JRE: 1.8.0_76-release-b198 x86_64
JVM: OpenJDK 64-Bit Server VM by JetBrains s.r.o

PyCharm: 4.5.5
Build #PY-141.3058, built on May 1, 2016
JRE: 1.8.0_102-b14.x86_64
JVM: Java HotSpot(TM) 64-Bit Server VM by Oracle Corporation
```