### PR TITLE
起動直後にも互換設定を読み込む

### DIFF
--- a/platform/mac/src/server/SKKServer.mm
+++ b/platform/mac/src/server/SKKServer.mm
@@ -109,6 +109,7 @@ static void terminate(int) {
     [self prepareBlacklistApps];
     imkserver_ = [self newIMKServer];
 
+    [self reloadBlacklistApps];
     [self reloadDictionarySet];
     [self reloadUserDefaults];
     [self reloadComponents];


### PR DESCRIPTION
https://github.com/codefirst/aquaskk/issues/54 の修正です。

普通に読み込むのを忘れてた。