### PR TITLE
JetBrains回避策(C-j, l, qを使えるようにする)

### DIFF
--- a/platform/mac/plist/BlacklistApps.plist
+++ b/platform/mac/plist/BlacklistApps.plist
@@ -10,15 +10,9 @@
 	</dict>
 	<dict>
 		<key>bundleIdentifier</key>
-		<string>com.jetbrains.pycharm</string>
+		<string>com.jetbrains</string>
 		<key>insertEmptyString</key>
-		<true/>
-		<key>insertMarkedText</key>
-		<true/>
-	</dict>
-	<dict>
-		<key>bundleIdentifier</key>
-		<string>com.jetbrains.intellij</string>
+		<false />
 		<key>insertMarkedText</key>
 		<true/>
 	</dict>

--- a/platform/mac/src/server/BlacklistApps.m
+++ b/platform/mac/src/server/BlacklistApps.m
@@ -71,11 +71,7 @@ static BlacklistApps* sharedData_ = nil;
 - (BOOL)isBlacklistApp:(NSString*)bundleIdentifier withKey:(NSString*)key {
     NSMutableDictionary* entry = [self getEntry: bundleIdentifier];
 
-    if(entry) {
-        return [entry[key] boolValue];
-    } else {
-      return NO;
-    }
+    return [entry[key] boolValue];
 }
 
 - (BOOL)isJavaApp:(NSBundle*)bundle {

--- a/platform/mac/src/server/BlacklistApps.m
+++ b/platform/mac/src/server/BlacklistApps.m
@@ -37,11 +37,12 @@ static BlacklistApps* sharedData_ = nil;
 }
 
 - (BOOL)isInsertEmptyString:(NSBundle *)bundle {
-    if([self isJavaApp:bundle]) {
-        return YES;
+    NSMutableDictionary* entry = [self getEntry:[bundle bundleIdentifier]];
+    if(entry) {
+        return [entry[@"insertEmptyString"] boolValue];
     }
 
-    if([self isBlacklistApp:[bundle bundleIdentifier] withKey:@"insertEmptyString"]) {
+    if([self isJavaApp:bundle]) {
         return YES;
     }
 
@@ -58,14 +59,23 @@ static BlacklistApps* sharedData_ = nil;
     return [self isBlacklistApp:bundleIdentifier withKey:@"insertMarkedText"];
 }
 
-- (BOOL)isBlacklistApp:(NSString*)bundleIdentifier withKey:(NSString*)key {
+- (NSMutableDictionary*)getEntry:(NSString*)bundleIdentifier{
     for (NSMutableDictionary* entry in blacklistApps_) {
-        if([bundleIdentifier hasPrefix: entry[@"bundleIdentifier"]] &&
-           [entry[key] boolValue] == YES) {
-            return YES;
+        if([bundleIdentifier hasPrefix: entry[@"bundleIdentifier"]]) {
+            return entry;
         }
     }
-    return NO;
+    return nil;
+}
+
+- (BOOL)isBlacklistApp:(NSString*)bundleIdentifier withKey:(NSString*)key {
+    NSMutableDictionary* entry = [self getEntry: bundleIdentifier];
+
+    if(entry) {
+        return [entry[key] boolValue];
+    } else {
+      return NO;
+    }
 }
 
 - (BOOL)isJavaApp:(NSBundle*)bundle {

--- a/platform/mac/src/server/SKKInputController.h
+++ b/platform/mac/src/server/SKKInputController.h
@@ -34,6 +34,7 @@ class MacInputModeWindow;
 
 @interface SKKInputController : IMKInputController {
     id <IMKTextInput, NSObject> client_;
+    NSTextInputContext* context_;
     BOOL activated_;
 
     SKKServerProxy* proxy_;

--- a/platform/mac/src/server/SKKInputMenu.mm
+++ b/platform/mac/src/server/SKKInputMenu.mm
@@ -31,6 +31,7 @@ namespace {
         SKKInputMode mode;
         NSString* identifier;
     } table[] = {
+        // InputMode
         { SKK_HIRAKANA_MODE, 		HirakanaInputMode,
           @"com.apple.inputmethod.Japanese.Hiragana" },
         { SKK_KATAKANA_MODE, 		KatakanaInputMode,
@@ -41,6 +42,18 @@ namespace {
           @"com.apple.inputmethod.Japanese.FullWidthRoman" },
         { SKK_ASCII_MODE,		AsciiInputMode,
           @"com.apple.inputmethod.Roman" },
+        // InputSource
+        { SKK_HIRAKANA_MODE, 		HirakanaInputMode,
+          @"jp.sourceforge.inputmethod.aquaskk.Hiragana" },
+        { SKK_KATAKANA_MODE, 		KatakanaInputMode,
+          @"jp.sourceforge.inputmethod.aquaskk.Katakana" },
+        { SKK_JISX0201KANA_MODE,	Jisx0201KanaInputMode,
+          @"jp.sourceforge.inputmethod.aquaskk.HalfWidthKana" },
+        { SKK_JISX0208LATIN_MODE,	Jisx0208LatinInputMode,
+          @"jp.sourceforge.inputmethod.aquaskk.FullWidthRoman" },
+        { SKK_ASCII_MODE,		AsciiInputMode,
+          @"jp.sourceforge.inputmethod.aquaskk.Ascii" },
+        // Error
         { SKK_NULL,			InvalidInputMode,
           0 }
     };


### PR DESCRIPTION
## 問題
#57 にあるようにJetBrains製品で以下のような問題がある。

 * C-jを押すと一文字前が消える
 * l/L/q/Qを押すと一文字前が消えることあがる

## 原因
互換性設定の「空文字挿入」が原因だと考えられる。

ただ、この互換設定を切ると、lを押すとlが入力される問題が再発する。

## 解決策
あきらめて karabiner で入力モード変更する。

<img width="494" alt="screen shot 2016-09-24 at 5 18 32 pm" src="https://cloud.githubusercontent.com/assets/9650/18807147/f25a2f94-827a-11e6-8993-14e0530e40d4.png">

```xml
<?xml version="1.0"?>
<root>
    <list>
        <item>
            <name>AquaSKK</name>
            <appdef>
                <appname>JetBrains</appname>
                <prefix>com.jetbrains.</prefix>
            </appdef>
            <inputsourcedef>
                <name>NonLatin</name>
                <inputsourceid_equal>jp.sourceforge.inputmethod.aquaskk.Hiragana</inputsourceid_equal>
                <inputsourceid_equal>jp.sourceforge.inputmethod.aquaskk.Katakana</inputsourceid_equal>
                <inputsourceid_equal>jp.sourceforge.inputmethod.aquaskk.HalfWidthKana</inputsourceid_equal>
            </inputsourcedef>

            <vkchangeinputsourcedef>
                <name>KeyCode::VK_CHANGE_INPUTSOURCE_AQUASKK_HIRAGANA</name>
                <inputsourceid_equal>jp.sourceforge.inputmethod.aquaskk.Hiragana</inputsourceid_equal>
            </vkchangeinputsourcedef>
            <vkchangeinputsourcedef>
                <name>KeyCode::VK_CHANGE_INPUTSOURCE_AQUASKK_KATAKANA</name>
                <inputsourceid_equal>jp.sourceforge.inputmethod.aquaskk.Katakana</inputsourceid_equal>
            </vkchangeinputsourcedef>
            <vkchangeinputsourcedef>
                <name>KeyCode::VK_CHANGE_INPUTSOURCE_AQUASKK_HALF_WIDTH_KANA</name>
                <inputsourceid_equal>jp.sourceforge.inputmethod.aquaskk.HalfWidthKana</inputsourceid_equal>
            </vkchangeinputsourcedef>
            <vkchangeinputsourcedef>
                <name>KeyCode::VK_CHANGE_INPUTSOURCE_AQUASKK_ASCII</name>
                <inputsourceid_equal>jp.sourceforge.inputmethod.aquaskk.Ascii</inputsourceid_equal>
            </vkchangeinputsourcedef>
            <vkchangeinputsourcedef>
                <name>KeyCode::VK_CHANGE_INPUTSOURCE_AQUASKK_FULL_WIDTH_ROMAN</name>
                <inputsourceid_equal>jp.sourceforge.inputmethod.aquaskk.FullWidthRoman</inputsourceid_equal>
            </vkchangeinputsourcedef>
            <list>              
                <item>
                    <name>workaround for JetBrains products</name>
                    <item>
                      <name>Change input source to ascii mode by l</name>
                      <identifier>private.aquaskk.jetbrains.ascii</identifier>
                      <inputsource_only>NonLatin</inputsource_only>
                      <only>JetBrains</only>
                      <autogen>
                          __KeyToKey__
                          KeyCode::L,
                          KeyCode::VK_CHANGE_INPUTSOURCE_AQUASKK_ASCII
                      </autogen>
                    </item>
                    <item>
                      <name>Change input source to katakana mode by q</name>
                      <identifier>private.aquaskk.jetbrains.katakana</identifier>
                      <inputsource_only>NonLatin</inputsource_only>
                      <only>JetBrains</only>
                      <autogen>
                          __KeyToKey__
                          KeyCode::Q,
                          KeyCode::VK_CHANGE_INPUTSOURCE_AQUASKK_KATAKANA
                      </autogen>
                    </item>
                </item>
            </list>
        </item>
    </list>
</root>
```

ただしAquaSKK外で入力モードを変更しているので、SKKが入力モードの変更を検知できず正常に動作しない。 

そこで、入力毎にシステムの入力モードと、AquaSKKが認識している入力モードがずれていないかを確認するようにした。

## 制限

 * AquaSKK統合モードでは使えない
 * karabinerの制約で L/Qには機能を割り当てれていない