### PR TITLE
キーボードレイアウトが無視されるのを修正

### DIFF
--- a/platform/mac/src/server/SKKInputController.mm
+++ b/platform/mac/src/server/SKKInputController.mm
@@ -124,8 +124,6 @@
 
     [self debug:@"activateServer"];
 
-    [self initializeKeyboardLayout];
-
     activated_ = YES;
 
     session_->Activate();
@@ -140,6 +138,8 @@
 }
 
 - (void)setValue:(id)value forTag:(long)tag client:(id)sender {
+    [self initializeKeyboardLayout];
+
     if([self directMode]) return;
 
     if(tag != kTextServiceInputModePropertyTag) return;


### PR DESCRIPTION
非統合モードでモード切り替えしたときや直接入力モードで、環境設定で指定したキーボードレイアウトが無視されるのを修正しました。
(修正内容が適切なのかは自信がありません……)