### PR TITLE
統合モードでもé等を入力できるようにした

### DIFF
--- a/platform/mac/proj/AquaSKK-Info.plist
+++ b/platform/mac/proj/AquaSKK-Info.plist
@@ -29,11 +29,11 @@
 				<key>TISInputSourceID</key>
 				<string>jp.sourceforge.inputmethod.aquaskk</string>
 				<key>TISIntendedLanguage</key>
-				<string>ja</string>
+				<string>en</string>
 				<key>tsInputModeAlternateMenuIconFileKey</key>
 				<string>AquaSKK-InputMethod.tif</string>
 				<key>tsInputModeDefaultStateKey</key>
-				<false/>
+				<true/>
 				<key>tsInputModeIsVisibleKey</key>
 				<true/>
 				<key>tsInputModeJISKeyboardShortcutKey</key>
@@ -45,7 +45,7 @@
 				<key>tsInputModePrimaryInScriptKey</key>
 				<true/>
 				<key>tsInputModeScriptKey</key>
-				<string>smJapanese</string>
+				<string>smRoman</string>
 			</dict>
 			<key>com.apple.inputmethod.Japanese.FullWidthRoman</key>
 			<dict>


### PR DESCRIPTION
統合モードではOption+e eでもéが入力できなかったので、対応した。

## 説明
plistでどの言語の入力メソッドかを設定できるが、日本語にするとéが入力できない。

そこで、このPRでは統合モードは英語の入力メソッド扱いにした。

## デメリット
英語の入力メソッドになるので、ここにでてくるようになる。

<img width="548" alt="screen shot 2016-11-15 at 22 43 25" src="https://cloud.githubusercontent.com/assets/9650/20307900/f0435590-ab84-11e6-9ab5-5484cb44709d.png">
