### PR TITLE
数値変換で「100000000えん」が「一億万円」になる問題を修正

### DIFF
--- a/src/engine/backend/SKKNumericConverter.cpp
+++ b/src/engine/backend/SKKNumericConverter.cpp
@@ -116,6 +116,7 @@ static std::string ConvertType3(const std::string& src) {
     const char* unit1[] = { "", "万", "億", "兆", "京", "垓" };
     const char* unit2[] = { "十", "百", "千" };
     std::string result;
+    unsigned int previous_size = 0;
 
     if(src.size() == 1 && src[0] == '0') {
 	return "〇";
@@ -156,7 +157,11 @@ static std::string ConvertType3(const std::string& src) {
 	    if(src[i] == '1') {
 		result += "一";
 	    }
-	    result += unit1[(distance - 1) / 4];
+	    // 「垓、京、兆、億、万」が連続しない場合に追加
+	    if(previous_size < result.size()) {
+	        result += unit1[(distance - 1) / 4];
+	        previous_size = result.size();
+	    }
 	} else {
 	    // 十の位以上
 	    if(distance > 1) {
@@ -189,6 +194,7 @@ static std::string ConvertType5(const std::string& src) {
     const char* unit1[] = { "", "萬", "億", "兆", "京", "垓" };
     const char* unit2[] = { "拾", "百", "阡" };
     std::string result;
+    unsigned int previous_size = 0;
 
     if(src.size() == 1 && src[0] == '0') {
 	return "零";
@@ -229,7 +235,11 @@ static std::string ConvertType5(const std::string& src) {
 
 	// 「十、百、千」以外の位
 	if(distance > 4 && (distance - 1) % 4 == 0) {
-	    result += unit1[(distance - 1) / 4];
+	    // 「垓、京、兆、億、萬」が連続しない場合に追加
+	    if (previous_size < result.size()){
+	        result += unit1[(distance - 1) / 4];
+	        previous_size = result.size();
+	    }
 	} else {
 	    // 十の位以上
 	    if(distance > 1) {


### PR DESCRIPTION
数値変換の＃3(漢数字位取りあり)と＃5(小切手・手形)で余分な京・兆・億・万が追加される場合がありましたので修正しました。

＃3の例(字体は違いますが＃5も同様です)
修正前
▽100000000　→　一億万 //万が余分
▽100011111　→　一億一万千百十一 //正しい
▽100001111　→　一億万千百十一 //万が余分
▽10000000000000000　→　一京兆億万 //兆億万が余分

修正後
▽100000000　→　一億
▽100011111　→　一億一万千百十一
▽100001111　→　一億千百十一
▽10000000000000000　→　一京