### PR TITLE
候補ウインドウ用のフォントが見つからないときのフォールバック処理を追加

### DIFF
--- a/platform/mac/src/preferences/PreferenceController.mm
+++ b/platform/mac/src/preferences/PreferenceController.mm
@@ -62,7 +62,12 @@ namespace {
 
         NSString* fontName = [preferences_ objectForKey:SKKUserDefaultKeys::candidate_window_font_name];
         NSNumber* fontSize =  [preferences_ objectForKey:SKKUserDefaultKeys::candidate_window_font_size];
-        candidateWindowFont_ = [[NSFont fontWithName:fontName size:[fontSize floatValue]] retain];
+        candidateWindowFont_ =
+            [NSFont fontWithName:fontName size:[fontSize floatValue]] ?:
+            [NSFont labelFontOfSize:[fontSize floatValue]];
+
+        [candidateWindowFont_ retain];
+
         proxy_ = [[SKKServerProxy alloc] init];
 
         NSValueTransformer* transformer

--- a/platform/mac/src/server/MacCandidateWindow.mm
+++ b/platform/mac/src/server/MacCandidateWindow.mm
@@ -120,7 +120,7 @@ void MacCandidateWindow::reloadUserDefaults() {
     NSString* fontName = [defaults stringForKey:SKKUserDefaultKeys::candidate_window_font_name];
     float fontSize = [defaults floatForKey:SKKUserDefaultKeys::candidate_window_font_size];
 
-    NSFont* font = [NSFont fontWithName:fontName size:fontSize];
+    NSFont* font = [NSFont fontWithName:fontName size:fontSize] ?: [NSFont labelFontOfSize:fontSize];
 
     NSString* labels = [defaults stringForKey:SKKUserDefaultKeys::candidate_window_labels];
     cellCount_ = [labels length];


### PR DESCRIPTION
## 再現手順
 1. Font Bookから「Trebuchet MS」を削除する
 2. ログアウト・ログインをし、AquaSKKを再起動する

## 発生する現象
AquaSKKによる入力ができなくなり、以下のログが出力される。

```
exception in IMKServer:
NSInvalidArgumentException
*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[0]
(null)
(
0 CoreFoundation 0x00007fff5802ffcb __exceptionPreprocess + 171
1 libobjc.A.dylib 0x00007fff7eccec76 objc_exception_throw + 48
2 CoreFoundation 0x00007fff58071264 _CFThrowFormattedException + 202
3 CoreFoundation 0x00007fff57f336c2 -[__NSPlaceholderDictionary initWithObjects:forKeys:count:] + 322
4 CoreFoundation 0x00007fff580c083b __createDictionary + 43
5 CoreFoundation 0x00007fff57fa20bf +[NSDictionary dictionaryWithObject:forKey:] + 47
6 AquaSKK 0x000000010b8b4819 -[CandidateCell initWithFont:] + 185
7 AquaSKK 0x000000010b8b6c9c -[CandidateView newCandidateCell] + 76
8 AquaSKK 0x000000010b8b68c8 -[CandidateView
````

設定ウインドウの表示がおかしくなる。

<img width="592" alt="8f881409441857d3b8685937600e583e" src="https://user-images.githubusercontent.com/9650/35332519-1c62d5d6-0103-11e8-976d-20b73f944433.png">

## 変更内容
フォントがみつからない場合はシステムフォントを利用するようにする。

<img width="592" alt="screen shot 2018-01-24 at 12 36 31" src="https://user-images.githubusercontent.com/9650/35332559-3c27046e-0103-11e8-9222-0edfaac8b94d.png">