### PR TITLE
Make ESC-key handling better

### DIFF
--- a/data/config/keymap.conf
+++ b/data/config/keymap.conf
@@ -48,4 +48,4 @@ CompConversion		alt::hex::0x20||shift::hex::0x20
 # ======================================================================
 
 AlwaysHandled           group::keycode::0x66,0x68
-PseudoHandled           ctrl::l||hex::0x1b
+PseudoHandled           ctrl::l


### PR DESCRIPTION
Other input methods(e.g. Kotoeri, mozc) consume esc key, but AquaSKK didn't cosume esc.

https://docs.google.com/spreadsheets/d/1Csez0Hm6BqGHb9z0IT8027hYZHEPb_6cVGWjRzzoemk/edit#gid=0

This report is come from [unarist/rinsuki](https://twitter.com/unarist/status/986977026836840449).