### PR TITLE
Android Studioをデフォルトの互換性設定に追加

### DIFF
--- a/platform/mac/plist/BlacklistApps.plist
+++ b/platform/mac/plist/BlacklistApps.plist
@@ -20,6 +20,16 @@
 	</dict>
 	<dict>
 		<key>bundleIdentifier</key>
+		<string>com.google.android.studio</string>
+		<key>insertEmptyString</key>
+		<false/>
+		<key>insertMarkedText</key>
+		<true/>
+		<key>syncInputSource</key>
+		<true/>
+	</dict>
+	<dict>
+		<key>bundleIdentifier</key>
 		<string>jp.naver.line.mac</string>
 		<key>insertEmptyString</key>
 		<false/>


### PR DESCRIPTION
とりあえずJetBrainsファミリーと同じ設定にしてあります。
related: #81