### PR TITLE
ユーザー辞書の変更ボタンがおかしい問題を修正

### DIFF
--- a/platform/mac/src/preferences/PreferenceController.mm
+++ b/platform/mac/src/preferences/PreferenceController.mm
@@ -159,7 +159,7 @@ namespace {
     [panel setDirectoryURL:dirurl];
     [panel beginSheetModalForWindow:prefWindow_ completionHandler:^(NSInteger result) {
         if(result == NSOKButton) {
-            [preferences_ setObject:[[panel URL] absoluteString]
+            [preferences_ setObject:[[panel URL] path]
                              forKey:SKKUserDefaultKeys::user_dictionary_path];
         }
     }];


### PR DESCRIPTION
Fix #94 

- #56 とまったく同じことをやった
- `setObject` _vs_ `setValue`で何が違うのか？といったところは調べていないが、ひとまずこれで動作した
- テストを与えたり、この2つのロジックを共通化できたらよいという気もしたが、ひとまず修正した