### PR TITLE
Apple Silicon Mac でのインストール時の Rosetta 2 要求を抑制する

### DIFF
--- a/platform/mac/pkg/distribution.xml
+++ b/platform/mac/pkg/distribution.xml
@@ -7,7 +7,7 @@
     <allowed-os-versions>
         <os-version min="10.9.4" />
     </allowed-os-versions>
-    <options customize="never" require-scripts="false"/>
+    <options customize="never" require-scripts="false" hostArchitectures="x86_64,arm64"/>
     <choices-outline>
         <line choice="default">
             <line choice="org.codefirst.aquaskk.pkg"/>


### PR DESCRIPTION
Fixes #101
