### PR TITLE
Xcode 13でビルドし、notarytoolでpkgをnotarizeする

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,23 +9,23 @@ on:
 
 jobs:
   build:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
-      - run: sudo xcode-select -s /Applications/Xcode_12.5.1.app
+      - run: sudo xcode-select -s /Applications/Xcode_13.4.1.app
       - run: make debug
         working-directory: platform/mac
   test:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
-      - run: sudo xcode-select -s /Applications/Xcode_12.5.1.app
+      - run: sudo xcode-select -s /Applications/Xcode_13.4.1.app
       - run: make test
         working-directory: platform/mac
   release:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
-      - run: sudo xcode-select -s /Applications/Xcode_12.5.1.app
+      - run: sudo xcode-select -s /Applications/Xcode_13.4.1.app
       - run: make release
         working-directory: platform/mac

--- a/platform/mac/Makefile
+++ b/platform/mac/Makefile
@@ -64,8 +64,8 @@ pkg: release
 	productsign --sign $(PKG_SIGN_ID) $(WORKDIR)/aquaskk-dist.pkg AquaSKK.pkg
 
 notarize: pkg
-	xcrun altool --notarize-app --primary-bundle-id jp.sourceforge.inputmethod.aquaskk --file AquaSKK.pkg --username $(APPSTORECONNECT_USERNAME)
-	echo "you can staple the notarization ticket after it has been notarized successfully by executing: xcrun stapler staple AquaSKK.pkg"
+	xcrun notarytool submit --wait AquaSKK.pkg --apple-id $(APPSTORECONNECT_USERNAME) --team-id $(DEVELOPMENT_TEAM)
+	xcrun stapler staple AquaSKK.pkg
 
 dmg: pkg
 	rm -fr $(WORKDIR)


### PR DESCRIPTION

動作確認

```
make notarize DEVELOPMENT_TEAM=FPZK4WRGW7 APPSTORECONNECT_USERNAME=...
:
The staple and validate action worked!
```

```
pkgutil --check-signature AquaSKK.pkg
Package "AquaSKK.pkg":
   Status: signed by a developer certificate issued by Apple for distribution
   Notarization: trusted by the Apple notary service
   Signed with a trusted timestamp on: 2022-11-06 04:10:48 +0000
   Certificate Chain:
    1. Developer ID Installer: JUN BAN (FPZK4WRGW7)
       Expires: 2025-08-30 08:42:02 +0000
       SHA256 Fingerprint:
           EF 31 B5 D4 16 66 77 61 C2 F2 BE FD A4 12 F1 FC B1 46 2B 57 9E CB 
           91 20 37 D9 CF 42 84 7C D2 77
       ------------------------------------------------------------------------
    2. Developer ID Certification Authority
       Expires: 2027-02-01 22:12:15 +0000
       SHA256 Fingerprint:
           7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
           F2 9C 88 CF B0 B1 BA 63 58 7F
       ------------------------------------------------------------------------
    3. Apple Root CA
       Expires: 2035-02-09 21:40:36 +0000
       SHA256 Fingerprint:
           B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
           68 C5 BE 91 B5 A1 10 01 F0 24
```