### PR TITLE
Xcode 14でビルドする

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,20 +12,20 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
-      - run: sudo xcode-select -s /Applications/Xcode_13.4.1.app
+      - run: sudo xcode-select -s /Applications/Xcode_14.1.app
       - run: make debug
         working-directory: platform/mac
   test:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
-      - run: sudo xcode-select -s /Applications/Xcode_13.4.1.app
+      - run: sudo xcode-select -s /Applications/Xcode_14.1.app
       - run: make test
         working-directory: platform/mac
   release:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
-      - run: sudo xcode-select -s /Applications/Xcode_13.4.1.app
+      - run: sudo xcode-select -s /Applications/Xcode_14.1.app
       - run: make release
         working-directory: platform/mac

--- a/platform/mac/proj/AquaSKK-Info.plist
+++ b/platform/mac/proj/AquaSKK-Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.7.4</string>
+	<string>4.7.5</string>
 	<key>CFBundleSignature</key>
 	<string>askk</string>
 	<key>CFBundleVersion</key>

--- a/platform/mac/proj/AquaSKK.xcodeproj/project.pbxproj
+++ b/platform/mac/proj/AquaSKK.xcodeproj/project.pbxproj
@@ -971,7 +971,7 @@
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1250;
+				LastUpgradeCheck = 1410;
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "AquaSKK" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -1183,6 +1183,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -1226,6 +1227,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_MODEL_TUNING = "";
@@ -1252,6 +1254,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_MODEL_TUNING = "";
@@ -1266,6 +1269,7 @@
 					"$(inherited)",
 					"\"$(SRCROOT)/../../../src/engine/tests\"",
 				);
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				OTHER_LDFLAGS = (
@@ -1292,6 +1296,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_MODEL_TUNING = "";
@@ -1304,6 +1309,7 @@
 					"$(inherited)",
 					"\"$(SRCROOT)/../../../src/engine/tests\"",
 				);
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				OTHER_LDFLAGS = (
 					"-framework",
@@ -1329,6 +1335,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -1337,6 +1344,7 @@
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "AquaSKKPreferences-Info.plist";
 				INSTALL_PATH = "$(HOME)/Applications";
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				OTHER_LDFLAGS = (
 					"-framework",
@@ -1361,6 +1369,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -1368,6 +1377,7 @@
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "AquaSKKPreferences-Info.plist";
 				INSTALL_PATH = "$(HOME)/Applications";
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
 				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				OTHER_LDFLAGS = (
 					"-framework",

--- a/platform/mac/proj/AquaSKKPreferences-Info.plist
+++ b/platform/mac/proj/AquaSKKPreferences-Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.7.4</string>
+	<string>4.7.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2021-05-26</string>
+	<string>2022-11-06</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSUIElement</key>

--- a/platform/mac/src/gui/AnnotationView.mm
+++ b/platform/mac/src/gui/AnnotationView.mm
@@ -127,7 +127,7 @@
 
     NSScrollView* scrollView = [[NSScrollView alloc] initWithFrame:frame];
     [scrollView setHasVerticalScroller:YES];
-    [[scrollView verticalScroller] setControlSize:NSSmallControlSize];
+    [[scrollView verticalScroller] setControlSize:NSControlSizeSmall];
 
     textView_ = [[NSTextView alloc] initWithFrame:[[scrollView contentView] frame]];
     [textView_ setEditable:NO];

--- a/platform/mac/src/gui/AnnotationWindow.mm
+++ b/platform/mac/src/gui/AnnotationWindow.mm
@@ -35,7 +35,7 @@
     if(self) {
         view_ = [[AnnotationView alloc] init];
         window_ = [[NSWindow alloc] initWithContentRect:[view_ frame]
-                                    styleMask:NSBorderlessWindowMask
+                                              styleMask:NSWindowStyleMaskBorderless
                                     backing:NSBackingStoreBuffered
                                     defer:YES];
         [window_ setContentView:view_];

--- a/platform/mac/src/gui/CandidateCell.mm
+++ b/platform/mac/src/gui/CandidateCell.mm
@@ -115,7 +115,7 @@
     } else {
         [[[NSColor blackColor] colorWithAlphaComponent:0.1] setFill];
     }
-    NSRectFillUsingOperation(focus, NSCompositeSourceOver);
+    NSRectFillUsingOperation(focus, NSCompositingOperationSourceOver);
 
     [[NSColor windowFrameColor] setStroke];
     [NSBezierPath strokeRect:focus];

--- a/platform/mac/src/gui/CandidateCell.mm
+++ b/platform/mac/src/gui/CandidateCell.mm
@@ -36,7 +36,7 @@
 - (id)initWithFont:(NSFont*)font {
     if(self = [super init]) {
 	entry_ = [[NSMutableAttributedString alloc] init];
-	attributes_ = [[NSDictionary dictionaryWithObjectsAndKeys:
+	attributes_ = [[NSMutableDictionary dictionaryWithObjectsAndKeys:
                     font, NSFontAttributeName,
                     [NSColor labelColor], NSForegroundColorAttributeName,
                     nil]

--- a/platform/mac/src/gui/CandidateView.mm
+++ b/platform/mac/src/gui/CandidateView.mm
@@ -53,7 +53,7 @@
     int margin = [CandidateView cellSpacing];
 
     NSPoint offset = NSMakePoint(margin, margin);
-    int cellCount = [labels_ length];
+    NSUInteger cellCount = [labels_ length];
 
     for(unsigned index = 0; index < [candidateCells_ count]; ++ index) {
         CandidateCell* cell = [candidateCells_ objectAtIndex:index];

--- a/platform/mac/src/gui/CandidateWindow.h
+++ b/platform/mac/src/gui/CandidateWindow.h
@@ -40,7 +40,7 @@
 - (void)setPage:(NSRange)page;
 - (void)showAt:(NSPoint)origin level:(int)level;
 - (void)hide;
-- (int)indexOfLabel:(char)label;
+- (NSUInteger)indexOfLabel:(char)label;
 - (id)newCandidateCell;
 
 @end

--- a/platform/mac/src/gui/CandidateWindow.mm
+++ b/platform/mac/src/gui/CandidateWindow.mm
@@ -84,7 +84,7 @@
     [window_ orderOut:nil];
 }
 
-- (int)indexOfLabel:(char)label {
+- (NSUInteger)indexOfLabel:(char)label {
     NSString* target = [NSString stringWithFormat:@"%c", label];
     NSRange result = [labels_ rangeOfString:target options:NSCaseInsensitiveSearch];
 

--- a/platform/mac/src/gui/CandidateWindow.mm
+++ b/platform/mac/src/gui/CandidateWindow.mm
@@ -36,7 +36,7 @@
     if(self) {
         view_ = [[CandidateView alloc] initWithFrame:NSZeroRect];
         window_ = [[NSWindow alloc] initWithContentRect:NSZeroRect
-                                    styleMask:NSBorderlessWindowMask
+                                              styleMask:NSWindowStyleMaskBorderless
                                     backing:NSBackingStoreBuffered
                                     defer:YES];
         [window_ setIgnoresMouseEvents:YES];

--- a/platform/mac/src/gui/CompletionWindow.mm
+++ b/platform/mac/src/gui/CompletionWindow.mm
@@ -35,7 +35,7 @@
     if(self) {
         view_ = [[CompletionView alloc] init];
         window_ = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 0, 0)
-                                    styleMask:NSBorderlessWindowMask
+                                              styleMask:NSWindowStyleMaskBorderless
                                     backing:NSBackingStoreBuffered
                                     defer:YES];
         [window_ setBackgroundColor:[NSColor clearColor]];

--- a/platform/mac/src/gui/InputModeWindow.mm
+++ b/platform/mac/src/gui/InputModeWindow.mm
@@ -40,7 +40,7 @@
 - (id)init {
     if(self = [super init]) {
         window_ = [[NSWindow alloc] initWithContentRect:NSZeroRect
-                                    styleMask:NSBorderlessWindowMask
+                                              styleMask:NSWindowStyleMaskBorderless
                                     backing:NSBackingStoreBuffered
                                     defer:YES];
         [window_ setBackgroundColor:[NSColor clearColor]];

--- a/platform/mac/src/gui/MessengerView.mm
+++ b/platform/mac/src/gui/MessengerView.mm
@@ -78,7 +78,7 @@
     pt.x = 3;
     pt.y = (NSHeight(frame) - [icon_ size].height) / 2.0;
 
-    [icon_ drawAtPoint:pt fromRect:NSZeroRect operation:NSCompositeSourceOver fraction:1.0];
+    [icon_ drawAtPoint:pt fromRect:NSZeroRect operation:NSCompositingOperationSourceOver fraction:1.0];
     [message_ drawAtPoint:NSMakePoint(pt.x + [icon_ size].width + 2, 4) withAttributes:attributes_];
 }
 

--- a/platform/mac/src/gui/MessengerWindow.mm
+++ b/platform/mac/src/gui/MessengerWindow.mm
@@ -36,7 +36,7 @@
     if(self) {
         view_ = [[MessengerView alloc] init];
         window_ = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 0, 0)
-                                    styleMask:NSBorderlessWindowMask
+                                              styleMask:NSWindowStyleMaskBorderless
                                     backing:NSBackingStoreBuffered
                                     defer:YES];
         [window_ setBackgroundColor:[NSColor clearColor]];

--- a/platform/mac/src/preferences/DictionarySet.mm
+++ b/platform/mac/src/preferences/DictionarySet.mm
@@ -93,7 +93,7 @@ static NSString* DictionaryRowsType = @"DictionaryRowsType";
 
     [panel setDirectoryURL:dirurl];
     [panel beginSheetModalForWindow:prefView completionHandler:^(NSInteger result) {
-        if(result == NSOKButton) {
+        if(result == NSModalResponseOK) {
             [[self selection] setValue:[[panel URL] path]
                                 forKey:SKKDictionarySetKeys::location];
         }

--- a/platform/mac/src/preferences/DictionarySet.mm
+++ b/platform/mac/src/preferences/DictionarySet.mm
@@ -30,8 +30,8 @@ static NSString* DictionaryRowsType = @"DictionaryRowsType";
 - (void)moveObjectsInArrangedObjectsFromIndexes:(NSIndexSet*)indexSet toIndex:(unsigned int)insertIndex {
     NSArray* objects = [self arrangedObjects];
     NSUInteger idx = [indexSet lastIndex];
-    int aboveInsertIndexCount = 0;
-    int removeIndex;
+    NSUInteger aboveInsertIndexCount = 0;
+    NSUInteger removeIndex;
 
     while(NSNotFound != idx) {
 	if(idx >= insertIndex) {
@@ -102,7 +102,7 @@ static NSString* DictionaryRowsType = @"DictionaryRowsType";
 
 - (BOOL)tableView:(NSTableView*)tv writeRowsWithIndexes:(NSIndexSet*)rowIndexes toPasteboard:(NSPasteboard*)pboard {
     NSArray* typesArray = [NSArray arrayWithObjects:DictionaryRowsType, nil];
-    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:rowIndexes];
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:rowIndexes requiringSecureCoding:YES error:nil];
 
     [pboard declareTypes:typesArray owner:self];
     [pboard setData:data forType:DictionaryRowsType];
@@ -141,7 +141,7 @@ static NSString* DictionaryRowsType = @"DictionaryRowsType";
 
     NSPasteboard* pboard = [info draggingPasteboard];
     NSData* rowData = [pboard dataForType:DictionaryRowsType];
-    NSIndexSet* rowIndexes = [NSKeyedUnarchiver unarchiveObjectWithData:rowData];
+    NSIndexSet* rowIndexes = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSIndexSet class] fromData:rowData error:nil];
 
     [self moveObjectsInArrangedObjectsFromIndexes:rowIndexes toIndex:row];
 

--- a/platform/mac/src/preferences/PreferenceController.mm
+++ b/platform/mac/src/preferences/PreferenceController.mm
@@ -141,7 +141,7 @@ namespace {
 }
 
 - (void)keyboardLayoutDidChange:(id)sender {
-    int index = [layoutPopUp_ indexOfSelectedItem];
+    NSInteger index = [layoutPopUp_ indexOfSelectedItem];
     NSString* selectedLayout = [layoutNames_ objectAtIndex:index];
 
     if(selectedLayout) {

--- a/platform/mac/src/preferences/PreferenceController.mm
+++ b/platform/mac/src/preferences/PreferenceController.mm
@@ -158,7 +158,7 @@ namespace {
 
     [panel setDirectoryURL:dirurl];
     [panel beginSheetModalForWindow:prefWindow_ completionHandler:^(NSInteger result) {
-        if(result == NSOKButton) {
+        if(result == NSModalResponseOK) {
             [preferences_ setObject:[[panel URL] path]
                              forKey:SKKUserDefaultKeys::user_dictionary_path];
         }

--- a/platform/mac/src/server/MacCandidateWindow.h
+++ b/platform/mac/src/server/MacCandidateWindow.h
@@ -34,7 +34,7 @@ class MacCandidateWindow : public SKKCandidateWindow {
     NSMutableArray* candidates_;
     NSRange page_;
     int cursor_;
-    int cellCount_;
+    NSUInteger cellCount_;
     CandidateWindow* window_;
 
     void reloadUserDefaults();

--- a/platform/mac/src/server/MacCandidateWindow.mm
+++ b/platform/mac/src/server/MacCandidateWindow.mm
@@ -109,7 +109,7 @@ void MacCandidateWindow::Update(SKKCandidateIterator begin, SKKCandidateIterator
 }
 
 int MacCandidateWindow::LabelIndex(char label) {
-    return [window_ indexOfLabel:label];
+    return (int)[window_ indexOfLabel:label];
 }
 
 // ------------------------------------------------------------

--- a/platform/mac/src/server/MacClipboard.mm
+++ b/platform/mac/src/server/MacClipboard.mm
@@ -25,8 +25,8 @@
 const std::string MacClipboard::PasteString() {
     NSPasteboard* pasteboard = [NSPasteboard generalPasteboard];
 
-    if([[pasteboard types] containsObject:NSStringPboardType] == YES) {
-        NSString* str = [pasteboard stringForType:NSStringPboardType];
+    if([[pasteboard types] containsObject:NSPasteboardTypeString] == YES) {
+        NSString* str = [pasteboard stringForType:NSPasteboardTypeString];
         return [str UTF8String];
     }
 

--- a/platform/mac/src/server/MacConfig.mm
+++ b/platform/mac/src/server/MacConfig.mm
@@ -71,7 +71,7 @@ bool MacConfig::DeleteOkuriWhenQuit() {
 int MacConfig::integerConfig(NSString* key) {
     NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
 
-    return [defaults integerForKey:key];
+    return (int)[defaults integerForKey:key];
 }
 
 bool MacConfig::boolConfig(NSString* key) {

--- a/platform/mac/src/server/MacInputModeWindow.mm
+++ b/platform/mac/src/server/MacInputModeWindow.mm
@@ -38,10 +38,7 @@ namespace {
     }
 
     int ActiveProcessID() {
-        NSDictionary* info = [[NSWorkspace sharedWorkspace] activeApplication];
-        NSNumber* pid = [info objectForKey:@"NSApplicationProcessIdentifier"];
-
-        return [pid intValue];
+        return [[NSWorkspace sharedWorkspace] frontmostApplication].processIdentifier;
     }
 
     typedef std::vector<CGRect> CGRectContainer;
@@ -98,7 +95,7 @@ namespace {
     CGRectContainer list = CreateWindowBoundsListOf(ActiveProcessID());
 
     // カーソル位置がウィンドウ矩形に含まれていなければ無視する
-    int count = std::count_if(list.begin(), list.end(),
+    long count = std::count_if(list.begin(), list.end(),
                               std::bind2nd(std::ptr_fun(CGRectContainsPoint), cursor));
     if(!count) {
         return;

--- a/platform/mac/src/server/SKKInputController.mm
+++ b/platform/mac/src/server/SKKInputController.mm
@@ -398,6 +398,8 @@
         [self changeInputMode:context_.selectedKeyboardInputSource];
         return system;
     }
+
+    return current;
 }
 
 - (void)cancelKeyEventForASCII {

--- a/platform/mac/src/server/SKKInputController.mm
+++ b/platform/mac/src/server/SKKInputController.mm
@@ -287,7 +287,7 @@
     [alert addButtonWithTitle:@"OK"];
     [alert setMessageText:@"デバッグ情報"];
     [alert setInformativeText:info];
-    [alert setAlertStyle:NSInformationalAlertStyle];
+    [alert setAlertStyle:NSAlertStyleInformational];
     [alert setIcon:[NSImage imageNamed:NSImageNameInfo]];
     [[alert window] setLevel:kCGPopUpMenuWindowLevel];
     [[alert window] setTitle:@"AquaSKK"];
@@ -296,8 +296,8 @@
 
     NSPasteboard* pb = [NSPasteboard generalPasteboard];
 
-    [pb declareTypes:[NSArray arrayWithObjects:NSStringPboardType, nil] owner:self];
-    [pb setString:info forType:NSStringPboardType];
+    [pb declareTypes:[NSArray arrayWithObjects:NSPasteboardTypeString, nil] owner:self];
+    [pb setString:info forType:NSPasteboardTypeString];
 
     [info release];
 }

--- a/platform/mac/src/server/SKKPreProcessor.mm
+++ b/platform/mac/src/server/SKKPreProcessor.mm
@@ -50,22 +50,22 @@ SKKEvent SKKPreProcessor::Execute(const NSEvent* event) {
     int keycode = [event keyCode];
     int mods = 0;
 
-    if([event modifierFlags] & NSShiftKeyMask) {
+    if([event modifierFlags] & NSEventModifierFlagShift) {
 	if(std::isgraph(dispchar)) { // 空白類を除いた英数字記号
 	    charcode = dispchar;
 	}
 	mods += SKKKeyState::SHIFT;
     }
 
-    if([event modifierFlags] & NSControlKeyMask) {
+    if([event modifierFlags] & NSEventModifierFlagControl) {
 	mods += SKKKeyState::CTRL;
     }
 
-    if([event modifierFlags] & NSAlternateKeyMask) {
+    if([event modifierFlags] & NSEventModifierFlagOption) {
 	mods += SKKKeyState::ALT;
     }
 
-    if([event modifierFlags] & NSCommandKeyMask) {
+    if([event modifierFlags] & NSEventModifierFlagCommand) {
 	mods += SKKKeyState::META;
     }
 
@@ -76,7 +76,7 @@ SKKEvent SKKPreProcessor::Execute(const NSEvent* event) {
 
     SKKEvent result = keymap_.Fetch(charcode, keycode, mods);
 
-    if([event modifierFlags] & NSAlphaShiftKeyMask) {
+    if([event modifierFlags] & NSEventModifierFlagCapsLock) {
         result.option |= CapsLock;
     }
 

--- a/platform/mac/src/server/SKKServer.mm
+++ b/platform/mac/src/server/SKKServer.mm
@@ -153,8 +153,8 @@ static void terminate(int) {
     flag = [defaults boolForKey:SKKUserDefaultKeys::enable_private_mode] == YES;
     SKKBackEnd::theInstance().EnablePrivateMode(flag);
 
-    int length = [defaults integerForKey:SKKUserDefaultKeys::minimum_completion_length];
-    SKKBackEnd::theInstance().SetMinimumCompletionLength(length);
+    NSInteger length = [defaults integerForKey:SKKUserDefaultKeys::minimum_completion_length];
+    SKKBackEnd::theInstance().SetMinimumCompletionLength((int)length);
 }
 
 - (void)reloadDictionarySet {

--- a/src/engine/backend/SKKNumericConverter.cpp
+++ b/src/engine/backend/SKKNumericConverter.cpp
@@ -116,13 +116,13 @@ static std::string ConvertType3(const std::string& src) {
     const char* unit1[] = { "", "万", "億", "兆", "京", "垓" };
     const char* unit2[] = { "十", "百", "千" };
     std::string result;
-    unsigned int previous_size = 0;
+    unsigned long previous_size = 0;
 
     if(src.size() == 1 && src[0] == '0') {
 	return "〇";
     }
 
-    for(unsigned i = src.find_first_not_of("0"); i < src.size(); ++ i) {
+    for(unsigned long i = src.find_first_not_of("0"); i < src.size(); ++ i) {
 	switch(src[i]) {
 	case '2':
 	    result += "二";
@@ -150,7 +150,7 @@ static std::string ConvertType3(const std::string& src) {
 	    break;
 	}
 
-	int distance = src.size() - i;
+	unsigned long distance = src.size() - i;
 
 	// 「十、百、千」以外の位
 	if(distance > 4 && (distance - 1) % 4 == 0) {
@@ -194,13 +194,13 @@ static std::string ConvertType5(const std::string& src) {
     const char* unit1[] = { "", "萬", "億", "兆", "京", "垓" };
     const char* unit2[] = { "拾", "百", "阡" };
     std::string result;
-    unsigned int previous_size = 0;
+    unsigned long previous_size = 0;
 
     if(src.size() == 1 && src[0] == '0') {
 	return "零";
     }
 
-    for(unsigned i = src.find_first_not_of("0"); i < src.size(); ++ i) {
+    for(unsigned long i = src.find_first_not_of("0"); i < src.size(); ++ i) {
 	switch(src[i]) {
 	case '1':
 	    result += "壱";
@@ -231,7 +231,7 @@ static std::string ConvertType5(const std::string& src) {
 	    break;
 	}
 
-	int distance = src.size() - i;
+	unsigned long distance = src.size() - i;
 
 	// 「十、百、千」以外の位
 	if(distance > 4 && (distance - 1) % 4 == 0) {

--- a/src/engine/completer/SKKCompleter.cpp
+++ b/src/engine/completer/SKKCompleter.cpp
@@ -79,7 +79,7 @@ int SKKCompleter::minPosition() const {
 }
 
 int SKKCompleter::maxPosition() const {
-    return completions_.size() - 1;
+    return (int)(completions_.size() - 1);
 }
 
 void SKKCompleter::notify() {

--- a/src/engine/dictionary/SKKHttpDictionaryLoader.cpp
+++ b/src/engine/dictionary/SKKHttpDictionaryLoader.cpp
@@ -104,7 +104,7 @@ int SKKHttpDictionaryLoader::content_length(net::socket::tcpstream& http) {
     return length;
 }
 
-int SKKHttpDictionaryLoader::file_size(const std::string& path) const {
+long long SKKHttpDictionaryLoader::file_size(const std::string& path) const {
     struct stat st;
 
     if(stat(path.c_str(), &st) == 0) {
@@ -128,7 +128,7 @@ bool SKKHttpDictionaryLoader::download(net::socket::tcpstream& http, int length)
     }
 
     // ダウンロードに失敗したか？
-    int new_size = file_size(tmp_path_);
+    long long new_size = file_size(tmp_path_);
     if(new_size != length) {
         std::cerr << "SKKHttpDictionaryLoader::download(): size conflict: expected="
                   << length << ", actual=" << new_size << std::endl;
@@ -136,7 +136,7 @@ bool SKKHttpDictionaryLoader::download(net::socket::tcpstream& http, int length)
     }
 
     // 既存の辞書と比較して小さすぎないか？
-    int old_size = file_size(path_);
+    long long old_size = file_size(path_);
     if(old_size != 0) {
         const int safety_margin = 32 * 1024; // 32KB
 

--- a/src/engine/dictionary/SKKHttpDictionaryLoader.h
+++ b/src/engine/dictionary/SKKHttpDictionaryLoader.h
@@ -37,7 +37,7 @@ class SKKHttpDictionaryLoader : public SKKDictionaryLoader {
 
     bool request(net::socket::tcpstream& http);
     int content_length(net::socket::tcpstream& http);
-    int file_size(const std::string& path) const;
+    long long file_size(const std::string& path) const;
     bool download(net::socket::tcpstream& http, int length);
 
 public:

--- a/src/engine/entry/SKKEntry.cpp
+++ b/src/engine/entry/SKKEntry.cpp
@@ -34,7 +34,7 @@ void SKKEntry::SetEntry(const std::string& entry) {
     normal_entry_ = entry;
 
     if(!normal_entry_.empty()) {
-        unsigned last_index = normal_entry_.size() - 1;
+        unsigned long last_index = normal_entry_.size() - 1;
 
         // 見出し語末尾の prefix を取り除く(ex. "かk" → "か")
         if(normal_entry_.find_last_of(prefix_) == last_index) {

--- a/src/engine/selector/SKKWindowSelector.cpp
+++ b/src/engine/selector/SKKWindowSelector.cpp
@@ -114,7 +114,7 @@ bool SKKWindowSelector::Select(char label) {
 }
 
 void SKKWindowSelector::Show() {
-    window_->Update(view_.begin(), view_.end(), cursor_pos_, page_pos_ + 1, pages_.size());
+    window_->Update(view_.begin(), view_.end(), cursor_pos_, page_pos_ + 1, (int)pages_.size());
     window_->Show();
 }
 
@@ -133,7 +133,7 @@ int SKKWindowSelector::minPage() const {
 }
 
 int SKKWindowSelector::maxPage() const {
-    return pages_.size() - 1;
+    return (int)(pages_.size() - 1);
 }
 
 int SKKWindowSelector::minPosition() const {

--- a/src/engine/utility/pthreadutil.h
+++ b/src/engine/utility/pthreadutil.h
@@ -259,7 +259,7 @@ namespace pthread {
         std::deque<pthread_t> pool_;
         std::deque<task*> tasks_;
         bool should_terminate_;
-        unsigned idle_threads_;
+        unsigned long idle_threads_;
 
         static void* handler(void* param) {
             pool* self = reinterpret_cast<pool*>(param);

--- a/src/engine/utility/socketutil.h
+++ b/src/engine/utility/socketutil.h
@@ -322,11 +322,11 @@ namespace socket {
         }
 
         virtual int sync() {
-            int remain = pptr() - pbase();
+            long remain = pptr() - pbase();
             int offset = 0;
 
             while(0 < remain) {
-                int result = ::send(fd_, pbase() + offset, remain, 0);
+                ssize_t result = ::send(fd_, pbase() + offset, remain, 0);
                 if(result == -1) return -1;
 
                 remain -= result;
@@ -342,7 +342,7 @@ namespace socket {
             setg(eback(), eback(), eback());
 
             // fill buffer
-            int length = ::recv(fd_, gptr(), BUFFER_SIZE, 0);
+            ssize_t length = ::recv(fd_, gptr(), BUFFER_SIZE, 0);
             if(length == 0 || length == -1) return traits_type::eof();
 
             setg(eback(), gptr(), gptr() + length);
@@ -589,7 +589,7 @@ namespace socket {
             return select();
         }
 
-        int wait(long seconds, long micro_seconds = 0) {
+        int wait(long seconds, int micro_seconds = 0) {
             timeval tv;
 
             tv.tv_sec = seconds;

--- a/src/engine/utility/subrange.h
+++ b/src/engine/utility/subrange.h
@@ -43,7 +43,7 @@ class subrange {
     Iter end_;
 
     void adjust(Container& container, size_type pos, size_type length) {
-	unsigned size = container.size();
+	unsigned long size = container.size();
 
 	if(pos < size) {
 	    begin_ = container.begin() + pos;

--- a/src/engine/utility/utf8util.h
+++ b/src/engine/utility/utf8util.h
@@ -233,7 +233,7 @@ struct utf8 {
     //      if(common_prefix("1漢字2", "1漢字3") == "1漢字") { ...
     //
     static std::string common_prefix(const std::string&s1, const std::string& s2) {
-        int max = std::min(s1.size(), s2.size());
+        const unsigned long max = std::min(s1.size(), s2.size());
         utf8::const_iterator iter1(s1.begin());
         utf8::const_iterator iter2(s2.begin());
 


### PR DESCRIPTION
動作確認用リリース: https://github.com/codefirst/aquaskk/releases/tag/4.7.5

* Xcode 14.1
* recommended build settingsへのupdate
  * dead code strip
  * minimum deployment target = 10.14.6
* build warningsのうち比較的単純なものへ対処
  * int, longまわり (arch依存でビット幅不定のlongがあるが、主にc++の依存先コードによるので、あえてlongに合わせたところがある)
  * activeApplicationのpid → frontMostApplicationのpid
* github actions
  * Xcode指定 
  * macOSはまだ12しかないみたいなので13にしていない

Makefileは変更なしでnotarize動作OK